### PR TITLE
fix syntax, set it back to wildcard

### DIFF
--- a/aws-ssm-start-stop-cluster/template.yaml
+++ b/aws-ssm-start-stop-cluster/template.yaml
@@ -70,7 +70,7 @@ Resources:
           - !Ref TagValue
         AutomationAssumeRole:
           - !GetAtt SsmAutomationRole.Arn
-      ScheduleExpression: cron(0 1 ? * MON-FRI *) # 6pm MDT (0am UTC) Weekdays
+      ScheduleExpression: cron(0 1 ? * * *) # 6pm MDT (0am UTC)
       Targets:
         - Key: aws:NoOpAutomationTag
           Values:
@@ -92,7 +92,7 @@ Resources:
           - !Ref TagValue
         AutomationAssumeRole:
           - !GetAtt SsmAutomationRole.Arn
-      ScheduleExpression: cron(0 14 ? * MON-FRI *) # 8am MDT (2pm UTC) Weekdays
+      ScheduleExpression: cron(0 14 ? * * *) # 8am MDT (2pm UTC)
       Targets:
         - Key: aws:NoOpAutomationTag
           Values:


### PR DESCRIPTION
SSM doesnt like the cron expression where I tried to do Mon-Fri.
Looks like the script already catches weekends and ignores, so it should be fine anyway.
I deployed the other change from the previous PR where I wanted it to start 1 hour earlier.